### PR TITLE
Changes to reflect kebab-case decision (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,31 +196,31 @@ Example: `?subset=Lat(40:50),Lon(10:20)`
 
 Retrieve the subset of the coverage between 40 and 50 degrees North, 10 and 20 degrees East, for a coverage whose domain set and CRS define axes named `Lat` and `Lon`.
 
-**`rangeSubset`**
+**`range-subset`**
 
 Allows to retrieve only a subset of the bands available.
 
 The band names are listed as in the `id` member of the RangeType DataRecord fields.
 
-Example: `?rangeSubset=B02,B03,B04`
+Example: `?range-subset=B02,B03,B04`
 
 Retrieve only bands with IDs B02, B03 and B04.
 A 0-based index can also be used instead, based on the position of the band in the field array of the RangeType DataRecord.
 A `*` before or after a list of bands indicate all previous or subsequent bands, respectively.
 
-**`scaleSize`**, **`scaleFactor`** and **`scaleAxes`**
+**`scale-size`**, **`scale-factor`** and **`scale-axes`**
 
 Allows to specify scaling factors to apply to the resolution of the coverage, e.g. to retrieve an overview of the coverage, using one of those three query parameters.
 
-Example: `?scaleSize=Lon(800),Lat(400)`
+Example: `?scale-size=Lon(800),Lat(400)`
 
 Specify that 800 values along the longitude axis, and 400 values along the latitude axis are desired in the output.
 
-Example: `?scaleFactor=2`
+Example: `?scale-factor=2`
 
 Specify that the resolution of the data should be half that of the original data.
 
-Example: `?scaleAxes=Lon(2)`
+Example: `?scale-axes=Lon(2)`
 
 Specify that the resolution of the data along the longitude axis should be half that of the original data, while the resolution along the other axes
 remains unchanged.

--- a/standard/examples/examples_rangesubsetting.adoc
+++ b/standard/examples/examples_rangesubsetting.adoc
@@ -1,12 +1,12 @@
 These examples return a range subset of a coverage in the negotiated format, including domain set, range type (and metadata if applicable) to the extent than they can be described in that format:
 
-* {datasetAPI}/collections/{coverageid}/coverage?rangeSubset=B02,B03,B04 -- returns only the bands with IDs B02, B03 and B04 from the coverage
-* {datasetAPI}/collections/{coverageid}/coverage?rangeSubset=3,4,5 -- returns the 4th, 5th and 6th band (0-based indexing, as listed in the Range Type) from the coverage
-* {datasetAPI}/collections/{coverageid}/coverage?rangeSubset=B07,* -- returns the band B07 and all subsequent bands from the coverage
+* {datasetAPI}/collections/{coverageid}/coverage?range-subset=B02,B03,B04 -- returns only the bands with IDs B02, B03 and B04 from the coverage
+* {datasetAPI}/collections/{coverageid}/coverage?range-subset=3,4,5 -- returns the 4th, 5th and 6th band (0-based indexing, as listed in the Range Type) from the coverage
+* {datasetAPI}/collections/{coverageid}/coverage?range-subset=B07,* -- returns the band B07 and all subsequent bands from the coverage
 
 A `rangeset` resource, also supporting subsetting, may be available in some implementations, for some formats/media types.
 The following examples using this resource return only the sample values for a subset of a coverage in the negotiated format, without domain set, range type or metadata:
 
-* {datasetAPI}/collections/{coverageid}/rangeset?rangeSubset=B02,B03,B04 -- returns only the bands with IDs B02, B03 and B04 from the coverage
-* {datasetAPI}/collections/{coverageid}/rangeset?rangeSubset=3,4,5 -- returns the 4th, 5th and 6th band (0-based indexing, as listed in the Range Type) from the coverage
-* {datasetAPI}/collections/{coverageid}/rangeset?rangeSubset=B07,* -- returns the band B07 and all subsequent bands from the coverage
+* {datasetAPI}/collections/{coverageid}/rangeset?range-subset=B02,B03,B04 -- returns only the bands with IDs B02, B03 and B04 from the coverage
+* {datasetAPI}/collections/{coverageid}/rangeset?range-subset=3,4,5 -- returns the 4th, 5th and 6th band (0-based indexing, as listed in the Range Type) from the coverage
+* {datasetAPI}/collections/{coverageid}/rangeset?range-subset=B07,* -- returns the band B07 and all subsequent bands from the coverage

--- a/standard/examples/examples_scaling.adoc
+++ b/standard/examples/examples_scaling.adoc
@@ -1,6 +1,6 @@
 
 
-* {datasetAPI}/collections/{coverageid}/coverage?scaleSize=Lat(300),Lon(400) -- returns the entire coverage re-scaled to 300 pixels along its latitude axis, and 400 samples along its longitude axis in the negotiated format
-* {datasetAPI}/collections/{coverageid}/coverage/rangeset?subset=Lat(40:50),Lon(10:20)&scaleSize=Lat(300),Lon(400) -- returns a coverage cutout (sample values only) between (Lat: 40, Lon: 10) and (Lat: 50, Lon: 20), re-scaled to 300 pixels along its latitude axis, and 400 samples along its longitude axis in the negotiated format
-* {datasetAPI}/collections/{coverageid}/coverage?scaleFactor=1.5 -- returns a coverage re-scaled so as to contain 1.5 times less sample values along all of its axes
-* {datasetAPI}/collections/{coverageid}/coverage?scaleAxes=Lat(2) -- returns a coverage re-scaled so as to contain 2 times less sample values along its latitude axis, and all original values along all its other dimensions
+* {datasetAPI}/collections/{coverageid}/coverage?scale-size=Lat(300),Lon(400) -- returns the entire coverage re-scaled to 300 pixels along its latitude axis, and 400 samples along its longitude axis in the negotiated format
+* {datasetAPI}/collections/{coverageid}/coverage/rangeset?subset=Lat(40:50),Lon(10:20)&scale-size=Lat(300),Lon(400) -- returns a coverage cutout (sample values only) between (Lat: 40, Lon: 10) and (Lat: 50, Lon: 20), re-scaled to 300 pixels along its latitude axis, and 400 samples along its longitude axis in the negotiated format
+* {datasetAPI}/collections/{coverageid}/coverage?scale-factor=1.5 -- returns a coverage re-scaled so as to contain 1.5 times less sample values along all of its axes
+* {datasetAPI}/collections/{coverageid}/coverage?scale-axes=Lat(2) -- returns a coverage re-scaled so as to contain 2 times less sample values along its latitude axis, and all original values along all its other dimensions

--- a/standard/openapi/openapi.json
+++ b/standard/openapi/openapi.json
@@ -579,19 +579,17 @@
         }, {
           "$ref" : "#/components/parameters/subset"
         }, {
-          "$ref" : "#/components/parameters/rangeSubset"
+          "$ref" : "#/components/parameters/range-subset"
         }, {
-          "$ref" : "#/components/parameters/scaleFactor"
+          "$ref" : "#/components/parameters/scale-factor"
         }, {
-          "$ref" : "#/components/parameters/scaleAxis"
+          "$ref" : "#/components/parameters/scale-axes"
         }, {
-          "$ref" : "#/components/parameters/scaleSize"
+          "$ref" : "#/components/parameters/scale-size"
         }, {
-          "$ref" : "#/components/parameters/scaleExtent"
+          "$ref" : "#/components/parameters/subset-crs"
         }, {
-          "$ref" : "#/components/parameters/subsettingCrs"
-        }, {
-          "$ref" : "#/components/parameters/outputCrs"
+          "$ref" : "#/components/parameters/crs"
         }, {
           "$ref" : "#/components/parameters/interpolation"
         } ],
@@ -1213,7 +1211,7 @@
       "subset" : {
         "name" : "subset",
         "in" : "query",
-        "description" : "get a subset of the coverage by slicing or trimming among one axis",
+        "description" : "get a subset of the coverage by slicing or trimming along one or more axis",
         "required" : false,
         "style" : "form",
         "explode" : true,
@@ -1221,10 +1219,10 @@
           "type" : "string"
         }
       },
-      "rangeSubset" : {
-        "name" : "rangeSubset",
+      "range-subset" : {
+        "name" : "range-subset",
         "in" : "query",
-        "description" : "subset the resulting coverage by choosing and/or rearrange particular fields",
+        "description" : "subset the resulting coverage by choosing and/or re-arranging particular fields (bands)",
         "required" : false,
         "style" : "form",
         "explode" : true,
@@ -1232,10 +1230,10 @@
           "type" : "string"
         }
       },
-      "scaleFactor" : {
-        "name" : "scaleFactor",
+      "scale-factor" : {
+        "name" : "scale-factor",
         "in" : "query",
-        "description" : "scale the resulting coverage either among all axes by a given factor",
+        "description" : "scale the resulting coverage along all axis by a given factor.",
         "required" : false,
         "style" : "form",
         "explode" : true,
@@ -1243,10 +1241,10 @@
           "type" : "string"
         }
       },
-      "scaleAxis" : {
-        "name" : "scaleAxis",
+      "scale-axes" : {
+        "name" : "scale-axes",
         "in" : "query",
-        "description" : "scale the resulting coverage either among one axis by a given factor",
+        "description" : "scale the resulting coverage along one or more axis by a given factor.",
         "required" : false,
         "style" : "form",
         "explode" : true,
@@ -1254,10 +1252,10 @@
           "type" : "string"
         }
       },
-      "scaleSize" : {
-        "name" : "scaleSize",
+      "scale-size" : {
+        "name" : "scale-size",
         "in" : "query",
-        "description" : "scale the resulting coverage either among one axis to a given size",
+        "description" : "scale the resulting coverage along one or more axis to a given size in data cells/pixels",
         "required" : false,
         "style" : "form",
         "explode" : true,
@@ -1265,19 +1263,8 @@
           "type" : "string"
         }
       },
-      "scaleExtent" : {
-        "name" : "scaleExtent",
-        "in" : "query",
-        "description" : "scale the resulting coverage either among one axis to a given extent",
-        "required" : false,
-        "style" : "form",
-        "explode" : true,
-        "schema" : {
-          "type" : "string"
-        }
-      },
-      "subsettingCrs" : {
-        "name" : "subsettingcrs",
+      "subset-crs" : {
+        "name" : "subset-crs",
         "in" : "query",
         "description" : "specify the projection in which the subsets are expressed",
         "required" : false,
@@ -1287,8 +1274,8 @@
           "type" : "string"
         }
       },
-      "outputCrs" : {
-        "name" : "outputcrs",
+      "crs" : {
+        "name" : "crs",
         "in" : "query",
         "description" : "reproject the output coverage to the given",
         "required" : false,

--- a/standard/openapi/openapi.yaml
+++ b/standard/openapi/openapi.yaml
@@ -443,13 +443,12 @@ paths:
       parameters:
       - $ref: '#/components/parameters/coverageid'
       - $ref: '#/components/parameters/subset'
-      - $ref: '#/components/parameters/rangeSubset'
-      - $ref: '#/components/parameters/scaleFactor'
-      - $ref: '#/components/parameters/scaleAxis'
-      - $ref: '#/components/parameters/scaleSize'
-      - $ref: '#/components/parameters/scaleExtent'
-      - $ref: '#/components/parameters/subsettingCrs'
-      - $ref: '#/components/parameters/outputCrs'
+      - $ref: '#/components/parameters/range-subset'
+      - $ref: '#/components/parameters/scale-factor'
+      - $ref: '#/components/parameters/scale-axes'
+      - $ref: '#/components/parameters/scale-size'
+      - $ref: '#/components/parameters/subset-crs'
+      - $ref: '#/components/parameters/crs'
       - $ref: '#/components/parameters/interpolation'
       responses:
         "200":
@@ -1007,8 +1006,8 @@ components:
       explode: true
       schema:
         type: string
-    rangeSubset:
-      name: rangeSubset
+    range-subset:
+      name: range-subset
       in: query
       description: subset the resulting coverage by choosing and/or rearrange particular
         fields
@@ -1017,7 +1016,7 @@ components:
       explode: true
       schema:
         type: string
-    scaleFactor:
+    scale-factor:
       name: scaleFactor
       in: query
       description: scale the resulting coverage either among all axes by a given factor
@@ -1026,8 +1025,8 @@ components:
       explode: true
       schema:
         type: string
-    scaleAxis:
-      name: scaleAxis
+    scale-axes:
+      name: scale-axes
       in: query
       description: scale the resulting coverage either among one axis by a given factor
       required: false
@@ -1035,8 +1034,8 @@ components:
       explode: true
       schema:
         type: string
-    scaleSize:
-      name: scaleSize
+    scale-size:
+      name: scale-size
       in: query
       description: scale the resulting coverage either among one axis to a given size
       required: false
@@ -1044,17 +1043,8 @@ components:
       explode: true
       schema:
         type: string
-    scaleExtent:
-      name: scaleExtent
-      in: query
-      description: scale the resulting coverage either among one axis to a given extent
-      required: false
-      style: form
-      explode: true
-      schema:
-        type: string
-    subsettingCrs:
-      name: subsettingcrs
+    subset-crs:
+      name: subset-crs
       in: query
       description: specify the projection in which the subsets are expressed
       required: false
@@ -1062,8 +1052,8 @@ components:
       explode: true
       schema:
         type: string
-    outputCrs:
-      name: outputcrs
+    crs:
+      name: crs
       in: query
       description: reproject the output coverage to the given
       required: false

--- a/standard/requirements/coverage-rangesubset/REQ_cov-rangesubset-definition.adoc
+++ b/standard/requirements/coverage-rangesubset/REQ_cov-rangesubset-definition.adoc
@@ -2,11 +2,11 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/coverage-rangesubset/definition*
-^|A |The operation SHALL support a parameter `rangeSubset` with the following characteristics (using an Extended Backus Naur Form (EBNF) fragment):
+^|A |The operation SHALL support a parameter `range-subset` with the following characteristics (using an Extended Backus Naur Form (EBNF) fragment):
 
 [source,EBNF]
 ----
-  RangeSubsetSpec:   "rangeSubset"=band[,bandName]*
+  RangeSubsetSpec:   "range-subset"=band[,bandName]*
   band:              {bandName}|{bandIndex}|"*"
   bandName:          {text}
   bandIndex:         {number}

--- a/standard/requirements/coverage-scaling/REQ_cov-scaling-definition.adoc
+++ b/standard/requirements/coverage-scaling/REQ_cov-scaling-definition.adoc
@@ -2,23 +2,23 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/coverage-scaling/definition*
-^|A |The operation SHALL support a parameter `scaleSize` with the following characteristics (using an Extended Backus Naur Form (EBNF) fragment):
+^|A |The operation SHALL support a parameter `scale-size` with the following characteristics (using an Extended Backus Naur Form (EBNF) fragment):
 
 [source,EBNF]
 ----
-  ScalingSpec:       "scaleSize"=axisName({number})[,axisName({number})]*
+  ScalingSpec:       "scale-size"=axisName({number})[,axisName({number})]*
   axisName:          {text}
 
   Where:
      {number} is an integer or floating-point number, and
 
 ----
-^|B |The operation SHALL support `scaleFactor` numeric parameter.
-^|C |The operation SHALL support a parameter `scaleAxes` with the following characteristics (using an Extended Backus Naur Form (EBNF) fragment):
+^|B |The operation SHALL support `scale-factor` numeric parameter.
+^|C |The operation SHALL support a parameter `scale-axes` with the following characteristics (using an Extended Backus Naur Form (EBNF) fragment):
 
 [source,EBNF]
 ----
-  ScalingSpec:       "scaleAxes"=axisName({number})[,axisName({number})]*
+  ScalingSpec:       "scale-axes"=axisName({number})[,axisName({number})]*
   axisName:          {NCName}
 
   Where:

--- a/standard/requirements/coverage-scaling/REQ_cov-scaling-success.adoc
+++ b/standard/requirements/coverage-scaling/REQ_cov-scaling-success.adoc
@@ -2,9 +2,9 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Requirement {counter:req-id}* |*/req/coverage-scaling/success*
-^|A |The `scaleSize=AxisName(count)`, `scaleFactor=factor` and `scaleAxes=AxisName(factor)` parameters SHALL be supported for the coverage and range set resources.
-^|B |When `scaleSize` is used, the returned coverage SHALL contain exactly the specified number of sample values along each axis which is specified, and the original number of sample values for unspecified axes.
-^|C |When `scaleFactor` is used, for each axis, the returned coverage SHALL contain the number of original sampled values, divided by _factor_.
-^|D |When `scaleAxes` is used, for each axis specified, the returned coverage SHALL contain the number of original sampled values, divided by the _factor_ specified for that axis, and the original number of sample values for unspecified axes.
-^|E |When `scaleSize` is used together with subsetting, the requested number of samples SHALL be mapped to the subset dimensions specified, even if those dimensions fall partially outside the extent of the coverage.
+^|A |The `scale-size=AxisName(count)`, `scale-factor=factor` and `scale-axes=AxisName(factor)` parameters SHALL be supported for the coverage and range set resources.
+^|B |When `scale-size` is used, the returned coverage SHALL contain exactly the specified number of sample values along each axis which is specified, and the original number of sample values for unspecified axes.
+^|C |When `scale-factor` is used, for each axis, the returned coverage SHALL contain the number of original sampled values, divided by _factor_.
+^|D |When `scale-axes` is used, for each axis specified, the returned coverage SHALL contain the number of original sampled values, divided by the _factor_ specified for that axis, and the original number of sample values for unspecified axes.
+^|E |When `scale-size` is used together with subsetting, the requested number of samples SHALL be mapped to the subset dimensions specified, even if those dimensions fall partially outside the extent of the coverage.
 |===


### PR DESCRIPTION
- Also fixed some OpenAPI definitions: scaleAxis -> scale-axes ; removed scaleExtent which is no longer defined
- Changes to CRS query parameters (not yet defined in Core) in OpenAPI definition:
   subsettingCrs -> subset-crs
   outputCrs -> crs
 to be better in sync with Common/Features