### PR TITLE
Relying on `Prefer: handling=strict` for native resolution requests

### DIFF
--- a/standard/annex_ats.adoc
+++ b/standard/annex_ats.adoc
@@ -17,8 +17,8 @@ Abstract Test A.{counter:ats-summary}: /conf/core/coverage-fields-schema +
 Abstract Test A.{counter:ats-summary}: /conf/core/get-coverage +
 Abstract Test A.{counter:ats-summary}: /conf/core/response-headers +
 Abstract Test A.{counter:ats-summary}: /conf/core/preference-applied +
-Abstract Test A.{counter:ats-summary}: /conf/core/preference-handling +
-Abstract Test A.{counter:ats-summary}: /conf/core/native-resolution
+Abstract Test A.{counter:ats-summary}: /conf/core/preference-handling-interpolation +
+Abstract Test A.{counter:ats-summary}: /conf/core/preference-handling-resolution
 |===
 
 **Abstract Test A.{counter:ats-id}:** Conformance Success
@@ -121,8 +121,8 @@ header to be missing only if the interpolation remains constant at the server's 
 **Abstract Test A.{counter:ats-id}:** Interpolation Preference Handling
 [cols=">20h,<80d",width="100%"]
 |===
-|test id: |/conf/core/preference-handling
-|requirement: |/req/core/preference-handling
+|test id: |/conf/core/preference-handling-interpolation
+|requirement: |/req/core/preference-handling-interpolation
 |test purpose: |Verify the behavior of the `Prefer: handling` parameter when requesting a preference for client interpolation methods.
 |test method: |
 *Given:* An API Implementation claiming conformance to the OGC API - Coverages +
@@ -138,16 +138,17 @@ requirements classes), while varying the `Prefer: handling` configuration +
 **Abstract Test A.{counter:ats-id}:** Native Resolution
 [cols=">20h,<80d",width="100%"]
 |===
-|test id: |/conf/core/native-resolution
-|requirement: |/req/core/native-resolution
-|test purpose: |Verify that requests for native resolution are supported.
+|test id: |/conf/core/preference-handling-resolution
+|requirement: |/req/core/preference-handling-resolution
+|test purpose: |Verify that requests using `Prefer: handling=strict` without explicit resolution request always return native resolution or 413 error.
 |test method: |
 *Given:* An API implementation claiming conformance to the OGC API - Coverages - Part 1: Core standard +
-*When:* Requests are made to the coverage resource using the `resolution` query parameter +
+*When:* Requests are made to the coverage resource using the `Prefer: handling=strict` request header +
 *Then:* +
-- Assert that the implementation accepts requests where specific dimensions have empty resolution values (e.g., `resolution=Lat(),Lon(),time()`) and returns the coverage data at the native resolution for those dimensions. +
-- Assert that the implementation accepts a completely empty resolution parameter (e.g., `resolution=`) and either returns the coverage data at the native resolution for all dimensions or returns an HTTP `4xx` error code if the requested native payload size exceeds server processing limits. +
-- Assert that, if the implementation does not support scaling for a requested dimension and a non-empty resolution value is specified, the server returns an HTTP `4xx` error status code.
+- Assert that the implementation accepts requests using a `Prefer: handling=strict` request header. +
+- Assert that the implementation accepts either returns the coverage data at the native resolution for all dimensions or returns an HTTP `413` error code if
+the response payload size at the native resolution exceeds <<server-limits-recommendations,advertised server limits>> when no `resolution`, `width` or `height` query parameter explicitly requests otherwise. +
+- Assert that the implementation defaults to a `lenient` handling, where the server is allowed to default to a downsampled resolution instead of a `413` error per the <<downsampling-permission, downsampling permission>>.
 |===
 
 === Conformance Class: Spatial subsetting

--- a/standard/requirements/interpolation_recommendations.adoc
+++ b/standard/requirements/interpolation_recommendations.adoc
@@ -5,8 +5,10 @@
 [width="90%",cols="2,6a"]
 |===
 ^|*Permission {counter:per-id}* |*/per/core/downsampling*
-^|A |In the case where a response to a request without a `resolution`, `width`, or `height` parameters would be larger than an advertised server limit, an implementation
-MAY automatically downsample the coverage to a suitable resolution instead of returning a 4xx client error.
+^|A |In the case of a request not explicitly specifying a resolution for a particular dimension (with a `resolution`, `width`, or `height` query parameter)
+and for which a `Prefer: handling=strict` request header was not included with the request (see <<req_core-preference-handling-resolution>>),
+where the response would be larger than an <<server-limits-recommendations,advertised server limit>>, an implementation
+MAY automatically downsample the resolution of the coverage for that dimension to a suitable resolution instead of returning a 413 _Content Too Large_ client error.
 ^|B |In the case where a `resolution`, `width` or `height` does not explicitly specify dimensions for all spatial axes of the coverage, an implementation MAY automatically proportionately
 adjust one or more unspecified spatial dimensions.
 |===
@@ -14,6 +16,8 @@ adjust one or more unspecified spatial dimensions.
 NOTE: A client retrieving a coverage from an implementation advertising support for a (Spatial, Temporal or General) Scaling requirements class should explicitly use `resolution=` or
 e.g, `resolution=Lat(),Lon(),time(),pressure()` if it wants to ensure retrieving the coverage in the native resolution of one or more dimensions and prefers receiving an error
 instead of a downsampled version of the data.
+For ensuring native resolution data across any server, whether they support the `resolution` query parameter from a Scaling requirements class or not, clients can instead use
+the `Prefer: handling=strict` request header.
 
 ==== Permission to only support certain resolutions
 

--- a/standard/requirements/requirements_class_core.adoc
+++ b/standard/requirements/requirements_class_core.adoc
@@ -240,45 +240,46 @@ An explicit list of interpolation method for each dimension:
 ^|*Requirement {counter:req-id}* |*/req/core/preference-applied*
 ^|A | If an Implementation supports <<interpolation-preference, client preferences for interpolation>>,
 the Implementation SHALL use a response header `Preference-Applied:` when it applied the preference specified by the client, for example,
-`Preference-Applied: interpolation=Lat([ogc-interpolation:linear]),Lon([ogc-interpolation:linear])`,time([ogc-interpolation:linear]),pressure([ogc-interpolation:linear]) and
+`Preference-Applied: interpolation=Lat([ogc-interpolation:linear]),Lon([ogc-interpolation:linear]),time([ogc-interpolation:linear]),pressure([ogc-interpolation:linear])` and
 `Preference-Applied: properties-interpolation=landcover([ogc-interpolation:nearest-neighbor])`.
 |===
 
-==== Strict or lenient preference handling
+==== Strict or lenient request handling
 
-[[req_core-preference-handling]]
+[[req_core-preference-handling-interpolation]]
 [width="90%",cols="2,6a"]
 |===
-^|*Requirement {counter:req-id}* |*/req/core/preference-handling*
+^|*Requirement {counter:req-id}* |*/req/core/preference-handling-interpolation*
 ^|A | If an Implementation supports <<interpolation-preference, client preferences for interpolation>>,
-the Implementation SHALL support the `Prefer: handling` parameter defined in https://www.rfc-editor.org/rfc/rfc7240#section-4.4[RFC 7240 Section 4.4] where a value of `handling=lenient` would simply ignore an unsupported preference, while a
-value of `handling=strict` SHALL return a 4xx error if the server is not able to fulfill the preference of the client
-(note that the handling parameter applies to the request as a whole, rather than to any specific preference).
+the Implementation SHALL support the `Prefer: handling` request header defined in https://www.rfc-editor.org/rfc/rfc7240#section-4.4[RFC 7240 Section 4.4] where a value of
+`handling=lenient` would simply ignore an unsupported interpolation method preference, while a
+value of `handling=strict` SHALL return a 4xx error if the server is not able to fulfill the interpolation method preference of the client
 ^|B | If no handling preference is specified, the Implementation SHALL default to lenient handling for the purpose of
 interpolation preferences.
 |===
 
-==== Query parameter `resolution` (native resolution requested using empty values)
-
-[[req_core-native-resolution]]
-[width="90%",cols="2,6"]
+[[req_core-preference-handling-resolution]]
+[width="90%",cols="2,6a"]
 |===
-^|*Requirement {counter:req-id}* |*/req/core/native-resolution*
-^|A |An implementation SHALL accept a `resolution` query parameter for a GET operation on the coverage resource,
-for empty resolution values (e.g., `resolution=Lat(),Lon(),time()`) indicating a request for the <<term-native-resolution,native resolution>> of the corresponding dimension(s),
-as well as a completely empty resolution query parameter (e.g., `resolution=`) indicating a request for the native resolution of all dimensions,
-whether the implementation supports or not the <<rc_scaling_spatial, "Spatial Scaling">>, <<rc_scaling_spatial, "Temporal Scaling">> and/or <<rc_scaling_spatial, "General Scaling">> requirements classes.
-^|B |An implementation not supporting scaling for a dimension for which a non-empty value has been specified using the `resolution` query parameter SHALL return a 4xx error.
+^|*Requirement {counter:req-id}* |*/req/core/preference-handling-resolution*
+^|A | If an Implementation supporting the a <<rc_scaling_spatial, Scaling requirements class>> takes advantage of the <<downsampling-permission, downsampling permission>>,
+that Implementation SHALL support the `Prefer: handling` request header defined in https://www.rfc-editor.org/rfc/rfc7240#section-4.4[RFC 7240 Section 4.4].
+^|B | When a value of `handling=lenient` is specified, the downsampling permission SHALL be applicable, allowing to return a downsampled resolution for a dimension for which a
+resolution was not explicitly specified (using the `resolution`, `width` or `height` query parameter).
+^|C | When a value of `handling=strict` is specified, the downsampling permission SHALL NOT be applicable, and the implementation SHALL always return
+the native resolution for any dimensions for which a specific resolution was not explicitly requested, or a 413 _Content too large_ error if the response payload would exceed
+the <<server-limits-recommendations, advertised server limits>>.
+^|D | If no handling preference is specified, the Implementation SHALL default to lenient handling for the purpose of the downsampling permission.
 |===
 
-NOTE: An implementation not supporting scaling for any dimension (not conforming to any of the scaling requirements classes) can simply ignore the `resolution` query parameter, and return the data at the
-native resolution as if the query parameter was not used. The implementation would return an error if the selected subset or the whole coverage requested exceeds the server limits at this native resolution.
+NOTE: The handling parameter of the `Prefer:` request header applies to the request as a whole, rather than to any specific preference or other aspect of the request.
 
-IMPORTANT: Clients wishing to ensure they always retrieve a <<term-native-resolution,native resolution>> coverage can include in their coverage data request a `resolution` query parameter specifying all dimensions with empty values:
-`resolution=Lat(),Lon(),time()` (including any additional dimension), or a completely empty `resolution` query parameter: `resolution=`, regardless of whether the server implements any of the Scaling requirements classes.
-For most large datasets, these clients would also need to include subsetting parameters (`subset`, `bbox` and/or `datetime`, assuming the server supports the corresponding subsetting requirements classes) to avoid an error response due
-to requesting more data than allowed by the server limits.
+IMPORTANT: Clients wishing to ensure they always retrieve a <<term-native-resolution,native resolution>> coverage can include in their coverage data request a `Prefer: handling=strict` request header.
+For most large datasets, these clients would also need to include subsetting parameters (`subset`, `bbox` and/or `datetime`, assuming the server supports the corresponding
+subsetting requirements classes), or use `Range:` request headers if supported e.g., as per the <<rc_encoding-cog, COG requirements class>>, to avoid an error response due to
+requesting more data than allowed by the server limits.
 
+[[server-limits-recommendations]]
 ==== Server limits recommendations
 
 Implementations might wish to set certain limits regarding how much data clients can retrieve within a single request.

--- a/standard/requirements/requirements_class_coverage_scaling_general.adoc
+++ b/standard/requirements/requirements_class_coverage_scaling_general.adoc
@@ -33,6 +33,14 @@
 For example, `resolution=` and `resolution=pressure()` SHALL both be considered as requesting the native pressure resolution.
 |===
 
+IMPORTANT: Clients wishing to ensure they always retrieve a <<term-native-resolution,native resolution>> coverage from a server supporting a Scaling requirements class
+irrespective of the <<downsampling-permission, downsampling permission>> can include in their coverage data request a `resolution` query parameter specifying all dimensions
+with empty values such as `resolution=pressure()` (including any additional dimension), or a completely empty `resolution` query parameter: `resolution=`.
+For most large datasets, these clients would also need to include a subsetting parameter (`subset`, assuming the server supports the General subsetting requirements class)
+to avoid an error response due to requesting more data than allowed by the <<server-limits-recommendations,server limits>>.
+Alternatively, to ensure such a request also works with servers not implementing the `resolution` query parameter defined in the Scaling requirements classes, clients
+can specify instead the `Prefer: handling=strict` request header (see <<req_core-preference-handling-resolution>>).
+
 [[req_scaling-general_invalid-axis]]
 [width="90%",cols="2,6a"]
 |===

--- a/standard/requirements/requirements_class_coverage_scaling_spatial.adoc
+++ b/standard/requirements/requirements_class_coverage_scaling_spatial.adoc
@@ -32,6 +32,14 @@
 For example, `resolution=` and `resolution=Lat(),Lon()` SHALL both be considered as requesting the native spatial resolution.
 |===
 
+IMPORTANT: Clients wishing to ensure they always retrieve a <<term-native-resolution,native resolution>> coverage from a server supporting a Scaling requirements class
+irrespective of the <<downsampling-permission, downsampling permission>> can include in their coverage data request a `resolution` query parameter specifying all dimensions
+with empty values such as `resolution=Lat(),Lon()` (including any additional dimension), or a completely empty `resolution` query parameter: `resolution=`.
+For most large datasets, these clients would also need to include subsetting parameters (`subset` or `bbox`, assuming the server supports the Spatial subsetting requirements class)
+to avoid an error response due to requesting more data than allowed by the <<server-limits-recommendations,server limits>>.
+Alternatively, to ensure such a request also works with servers not implementing the `resolution` query parameter defined in the Scaling requirements classes, clients
+can specify instead the `Prefer: handling=strict` request header (see <<req_core-preference-handling-resolution>>).
+
 [[req_scaling-spatial_3d-axis]]
 [width="90%",cols="2,6a"]
 |===

--- a/standard/requirements/requirements_class_coverage_scaling_temporal.adoc
+++ b/standard/requirements/requirements_class_coverage_scaling_temporal.adoc
@@ -31,6 +31,14 @@
 For example, `resolution=` and `resolution=time()` SHALL both be considered as requesting the native resolution for the primary temporal dimension.
 |===
 
+IMPORTANT: Clients wishing to ensure they always retrieve a <<term-native-resolution,native resolution>> coverage from a server supporting a Scaling requirements class
+irrespective of the <<downsampling-permission, downsampling permission>> can include in their coverage data request a `resolution` query parameter specifying all dimensions
+with empty values such as `resolution=time()` (including any additional dimension), or a completely empty `resolution` query parameter: `resolution=`.
+For most large datasets, these clients would also need to include subsetting parameters (`subset` or `datetime`, assuming the server supports the Temporal subsetting requirements class)
+to avoid an error response due to requesting more data than allowed by the <<server-limits-recommendations,server limits>>.
+Alternatively, to ensure such a request also works with servers not implementing the `resolution` query parameter defined in the Scaling requirements classes, clients
+can specify instead the `Prefer: handling=strict` request header (see <<req_core-preference-handling-resolution>>).
+
 [[req_scaling-temporal_invalid-axis]]
 [width="90%",cols="2,6a"]
 |===


### PR DESCRIPTION
- Instead of requiring implementations of the Core req. class to support the `resolution` query parameter defined in the Scaling requirements classes
- resolution= is still supported to request native resolutions by servers implementing the scaling req. classes

cc. @fmigneault 